### PR TITLE
fix: object with hasOwnProperty key

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -21,6 +21,7 @@ const jsonValues = {
   jsonObjectWithFlatPropertiesAndStringValues: { a: 'a', b: 'b', c: 'c' },
   jsonObjectWithFlatPropertiesAndNumberValues: { a: 3, b: 2, c: 1 },
   jsonObjectWithFlatPropertiesAndMixedValues: { a: true, b: 'b', c: 12 },
+  jsonObjectWithHasOwnProperty: { a: true, hasOwnProperty: null },
 } as const;
 
 describe('a generate json patch function', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,12 +204,16 @@ export function generateJSONPatch(
           } else {
             compareObjects(newPath, leftValue, rightValue);
           }
-        } else if (leftJsonValue.hasOwnProperty(rightKey)) {
+        } else if (
+          Object.prototype.hasOwnProperty.call(leftJsonValue, rightKey)
+        ) {
           patch.push({ op: 'replace', path: newPath, value: rightValue });
         } else {
           patch.push({ op: 'add', path: newPath, value: rightValue });
         }
-      } else if (!leftJsonValue.hasOwnProperty(rightKey)) {
+      } else if (
+        !Object.prototype.hasOwnProperty.call(leftJsonValue, rightKey)
+      ) {
         patch.push({ op: 'add', path: newPath, value: rightValue });
       } else if (leftValue !== rightValue) {
         patch.push({ op: 'replace', path: newPath, value: rightValue });
@@ -218,12 +222,12 @@ export function generateJSONPatch(
 
     for (const leftKey in leftJsonValue) {
       if (
-        !leftJsonValue.hasOwnProperty(leftKey) ||
+        !Object.prototype.hasOwnProperty.call(leftJsonValue, leftKey) ||
         (hasPropertyFilter && !propertyFilter(leftKey, { side: 'left', path }))
       )
         continue;
 
-      if (!rightJsonValue.hasOwnProperty(leftKey)) {
+      if (!Object.prototype.hasOwnProperty.call(rightJsonValue, leftKey)) {
         let newPath =
           isArrayAtTop && path === '' ? `/${leftKey}` : `${path}/${leftKey}`;
         patch.push({ op: 'remove', path: newPath });


### PR DESCRIPTION
avoid exception if JSON object happens to have a `hasOwnProperty` key