### PR TITLE
fix: escape JSON pointer tokens in generated paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,12 +241,20 @@ export function generateJSONPatch(
 const tokenEscapedTildeRegExp = /~/g;
 const tokenEscapedSlashRegExp = /\//g;
 
+/**
+ * Escapes a JSON Pointer reference token per RFC 6901.
+ * Order matters: "~" must be replaced before "/" to preserve "~1" sequences.
+ */
 function escapeReferenceToken(token: string): string {
   return token
     .replace(tokenEscapedTildeRegExp, '~0')
     .replace(tokenEscapedSlashRegExp, '~1');
 }
 
+/**
+ * Builds an RFC 6901-compliant JSON Pointer path by escaping a key token
+ * and appending it to the current path.
+ */
 function buildPath(path: string, key: string): string {
   const escapedKey = escapeReferenceToken(key);
   if (path === '') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,8 +188,7 @@ export function generateJSONPatch(
       )
         continue;
 
-      let newPath =
-        isArrayAtTop && path === '' ? `/${rightKey}` : `${path}/${rightKey}`;
+      const newPath = buildPath(path, rightKey);
       const leftValue = leftJsonValue[rightKey];
       const rightValue = rightJsonValue[rightKey];
 
@@ -228,8 +227,7 @@ export function generateJSONPatch(
         continue;
 
       if (!Object.prototype.hasOwnProperty.call(rightJsonValue, leftKey)) {
-        let newPath =
-          isArrayAtTop && path === '' ? `/${leftKey}` : `${path}/${leftKey}`;
+        const newPath = buildPath(path, leftKey);
         patch.push({ op: 'remove', path: newPath });
       }
     }
@@ -238,6 +236,23 @@ export function generateJSONPatch(
   compareObjects('', before, after);
 
   return [...patch];
+}
+
+const tokenEscapedTildeRegExp = /~/g;
+const tokenEscapedSlashRegExp = /\//g;
+
+function escapeReferenceToken(token: string): string {
+  return token
+    .replace(tokenEscapedTildeRegExp, '~0')
+    .replace(tokenEscapedSlashRegExp, '~1');
+}
+
+function buildPath(path: string, key: string): string {
+  const escapedKey = escapeReferenceToken(key);
+  if (path === '') {
+    return `/${escapedKey}`;
+  }
+  return `${path}/${escapedKey}`;
 }
 
 function isPrimitiveValue(value: JsonValue): value is JsonValue {


### PR DESCRIPTION
## Summary

This PR fixes JSON Pointer path generation to be RFC 6901-compliant when object keys contain reserved characters.

Previously, generated patch paths used raw object keys, which produced invalid/ambiguous pointers for keys containing `/`, `~`, or empty string keys. This affected generated JSON Patch operations (`path` and `from`) and could break downstream patch application.

Closes #21.
cc @BrianHuf 

## What changed

### Added JSON Pointer token escaping in path construction:
- `~` -> `~0`
- `/` -> `~1`
- Centralized object-key path construction through a helper so add/replace/remove paths are consistently escaped.
- Kept implementation dependency-free (no new packages added).

### Tests added/updated

-  Escaping for keys with `/` and `~`
- RFC 6901 escape ordering case (`~1` token -> `~01`)
- Empty-string keys (`/` and nested trailing `/`)
- Non-reserved characters remain unescaped
- Escaped paths for `move` operations (`from` and `path`)
- `maxDepth` behavior with slash-containing keys